### PR TITLE
Skip javadoc creation in release script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ lib
 *iml
 .idea
 .vscode
+
+release.properties
+*.releaseBackup

--- a/util/release.sh
+++ b/util/release.sh
@@ -33,8 +33,8 @@ SCRIPTDIR=$(dirname "$0")
 pushd "$SCRIPTDIR"/..
 
 mvn release:clean
-mvn release:prepare --batch-mode -DreleaseVersion="$RELEASE_VERSION" -DdevelopmentVersion="$DEVELOPMENT_VERSION" -DtagNameFormat=v@{project.version} -Darguments="-DskipTests"
+mvn release:prepare --batch-mode -DreleaseVersion="$RELEASE_VERSION" -DdevelopmentVersion="$DEVELOPMENT_VERSION" -DtagNameFormat=v@{project.version} -Darguments="-DskipTests -Dmaven.javadoc.skip=true"
 # Deployment will be handled by GitHub actions
-mvn release:perform --batch-mode -Darguments="-Dmaven.deploy.skip=true"
+mvn release:perform --batch-mode -Darguments="-Dmaven.deploy.skip=true -Dmaven.javadoc.skip=true"
 
 popd


### PR DESCRIPTION
Some external dependencies seem to be broken.