### PR TITLE
Configurable geoserver ows path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.geoserver</groupId>
     <artifactId>geoserver</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.2</version>
   </parent>
 
   <groupId>org.geoserver.community</groupId>
@@ -47,7 +47,7 @@
   </distributionManagement>
 
   <properties>
-    <geoserver.version>2.21.0</geoserver.version>
+    <geoserver.version>2.22.2</geoserver.version>
     <frontend-maven-plugin.version>1.12.1</frontend-maven-plugin.version>
   </properties>
 

--- a/src/main/java/org/geoserver/wms/web/data/GeoStyler.java
+++ b/src/main/java/org/geoserver/wms/web/data/GeoStyler.java
@@ -25,6 +25,8 @@ import org.apache.wicket.markup.head.JavaScriptHeaderItem;
 import org.apache.wicket.markup.head.OnLoadHeaderItem;
 import org.apache.wicket.markup.html.IHeaderContributor;
 import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.request.Request;
+import org.apache.wicket.request.http.WebRequest;
 import org.apache.wicket.request.resource.PackageResourceReference;
 import org.apache.wicket.resource.NoOpTextCompressor;
 import org.geoserver.catalog.LayerInfo;
@@ -106,6 +108,8 @@ public class GeoStyler extends Panel implements IHeaderContributor {
             context.put("layerType", StringUtils.EMPTY);
         }
 
+        context.put("basePath", getContextPath() + "/ows");
+
         Template template = templates.getTemplate("geostyler-init.ftl");
         StringWriter script = new java.io.StringWriter();
         template.process(context, script);
@@ -158,5 +162,14 @@ public class GeoStyler extends Panel implements IHeaderContributor {
                 .getResourceSettings()
                 .setJavaScriptCompressor(new DefaultJavaScriptCompressor());
         super.onRemove();
+    }
+
+    private String getContextPath() {
+        final Request request = getRequest();
+        if (request instanceof WebRequest) {
+            final WebRequest wr = (WebRequest) request;
+            return wr.getContextPath();
+        }
+        return null;
     }
 }

--- a/src/main/resources/org/geoserver/wms/web/data/geostyler-init.ftl
+++ b/src/main/resources/org/geoserver/wms/web/data/geostyler-init.ftl
@@ -2,6 +2,7 @@
   // get infos from GeoServer
   var layerNames = '${layer}';
   var layerType = '${layerType}';
+  var basePath = '${basePath}';
 
   // append some divs to the DOM right above the code editor
   var root = document.createElement('div');
@@ -70,7 +71,7 @@
   if (layerType.toLowerCase() === 'vector') {
     var wfsParser = new GeoStylerWfsParser.WfsDataParser();
     getFeaturePromise = wfsParser.readData({
-      url: window.location.origin + '/geoserver/ows',
+      url: window.location.origin + basePath,
       version: '2.0.0',
       typeName: layerNames,
       srsName: 'EPSG:4326',


### PR DESCRIPTION
- Get rid of hardcoded endpoint `/geoserver/ows` and get it dynamically from context path instead
- Bump geoserver version v2.22.2

Please review @geostyler/devs
 