### PR TITLE
Only show GeoStyler for SLD Styles

### DIFF
--- a/src/main/java/org/geoserver/wms/web/data/GeoStyler.java
+++ b/src/main/java/org/geoserver/wms/web/data/GeoStyler.java
@@ -96,6 +96,16 @@ public class GeoStyler extends Panel {
      * @throws TemplateException
      */
     private void renderHeaderScript(IHeaderResponse header) throws IOException, TemplateException {
+        String styleFormat = parent.getStyleInfo().getFormat();
+
+        if (!styleFormat.equals("sld")) {
+            LOGGER.info(
+                    "Don't render GeoStyler for format "
+                            + styleFormat
+                            + " as it is not supported.");
+            return;
+        }
+
         Map<String, Object> context = new HashMap<>();
         LayerInfo layerInfo = parent.getLayerInfo();
         ResourceInfo resource = layerInfo.getResource();

--- a/src/main/resources/org/geoserver/wms/web/data/geostyler-init.ftl
+++ b/src/main/resources/org/geoserver/wms/web/data/geostyler-init.ftl
@@ -71,7 +71,7 @@
           visibility: false
         }
       },
-      RuelCard: {
+      RuleCard: {
         amountField: {
           visibility: false
         },


### PR DESCRIPTION
This adds a check to only show the GeoStyler UI when the format of the style is SLD.
It also fixes a typo in the GeoStylerContext config.

Fixes #156 