### PR TITLE
Update GeoServer to v2.26.0 and fix paths in Dockerfile

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,10 +1,9 @@
-version: '3.8'
 services:
   geoserver:
     build:
       context: ./geoserver
     ports:
-      - 8080:8080
+      - "8080:8080"
     environment:
       EXTRA_JAVA_OPTS: -Xms1g -Xmx2g
     volumes:

--- a/docker/geoserver/Dockerfile
+++ b/docker/geoserver/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.osgeo.org/geoserver:2.25.1
+FROM docker.osgeo.org/geoserver:2.26.0
 
-RUN rm -f /opt/apache-tomcat-9.0.68/webapps/geoserver/WEB-INF/lib/gs-geostyler-*.jar
+RUN rm -f /usr/local/tomcat/webapps/geoserver/WEB-INF/lib/gs-geostyler-*.jar

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geoserver-geostyler-module",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geoserver-geostyler-module",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "GPL-2.0-only",
       "dependencies": {
         "antd": "5.18.1",

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.geoserver</groupId>
     <artifactId>geoserver</artifactId>
-    <version>2.25.1</version>
+    <version>2.26.0</version>
   </parent>
 
   <groupId>org.geoserver.community</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,6 @@
   </distributionManagement>
 
   <properties>
-    <geoserver.version>2.25.1</geoserver.version>
     <frontend-maven-plugin.version>1.15.0</frontend-maven-plugin.version>
   </properties>
 
@@ -43,25 +42,25 @@
     <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-core</artifactId>
-      <version>${geoserver.version}</version>
+      <version>${gs.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-wms</artifactId>
-      <version>${geoserver.version}</version>
+      <version>${gs.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-core</artifactId>
-      <version>${geoserver.version}</version>
+      <version>${gs.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-main</artifactId>
-      <version>${geoserver.version}</version>
+      <version>${gs.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
In addition, the version of GeoServer is inherited from `org.geoserver.geoserver` parent now.

 https://github.com/geostyler/geostyler-geoserver-plugin/pull/160 should be merged before.

Subsumes also:
* https://github.com/geostyler/geostyler-geoserver-plugin/pull/157
* https://github.com/geostyler/geostyler-geoserver-plugin/pull/158
* https://github.com/geostyler/geostyler-geoserver-plugin/pull/159

Please review.